### PR TITLE
[12.0][FIX]Table name in SQL to prevent ambiguous order_id

### DIFF
--- a/addons/sale/migrations/12.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/12.0.1.1/pre-migration.py
@@ -90,8 +90,8 @@ def fill_sale_order_line_sections(cr):
             SELECT order_id
             FROM sale_order_line
             WHERE layout_category_id IS NOT NULL)
-        GROUP BY order_id, layout_category_id
-        ORDER BY order_id, layout_category_id, sequence
+        GROUP BY sol.order_id, sol.layout_category_id
+        ORDER BY sol.order_id, sol.layout_category_id, sequence
         """
     )
 


### PR DESCRIPTION
Working with some OCA modules, order_id column is added to sale_layout_category so this query is not working anymore :
```
2021-11-28 16:30:39,572 481373 ERROR defacto_12 odoo.sql_db: bad query: 
        INSERT INTO sale_order_line (order_id, layout_category_id,
            sequence, name,
            price_unit, product_uom_qty, customer_lead,
            display_type, create_uid, create_date, write_uid, write_date)
        SELECT sol.order_id, sol.layout_category_id,
            min(sol.sequence) -1 as sequence, max(COALESCE(slc.name, ' ')),
            0, 0, 0, 'line_section', min(sol.create_uid), min(sol.create_date),
            min(sol.write_uid), min(sol.write_date)
        FROM sale_order_line sol
        LEFT JOIN sale_layout_category slc ON slc.id = sol.layout_category_id
        WHERE sol.order_id IN (
            SELECT order_id
            FROM sale_order_line
            WHERE layout_category_id IS NOT NULL)
        GROUP BY order_id, layout_category_id
        ORDER BY order_id, layout_category_id, sequence
        
ERROR: ERREUR:  la référence à la colonne « order_id » est ambigu
LIGNE 16 :         GROUP BY order_id, layout_category_id
                            ^
```
This easy patch is fixing this